### PR TITLE
windows系统，语言切换为英语时，此时帕拉卡中使用中文路径就会识别不了；

### DIFF
--- a/Client/trunk/ParaEngineClient/Core/ParaEngineAppBase.cpp
+++ b/Client/trunk/ParaEngineClient/Core/ParaEngineAppBase.cpp
@@ -786,7 +786,12 @@ bool CParaEngineAppBase::FindParaEngineDirectory(const char* sHint)
 				bFoundSigFile = true;
 			if (bFoundSigFile)
 			{
+#ifdef DEFAULT_FILE_ENCODING
+				LPCWSTR workingDir16 = StringHelper::MultiByteToWideChar(workingDir.c_str(), DEFAULT_FILE_ENCODING);
+				::SetCurrentDirectoryW(workingDir16);
+#else
 				::SetCurrentDirectory(workingDir.c_str());
+#endif
 			}
 			else
 			{
@@ -803,7 +808,15 @@ bool CParaEngineAppBase::FindParaEngineDirectory(const char* sHint)
 	{
 		char sWorkingDir[512 + 1] = { 0 };
 		memset(sWorkingDir, 0, sizeof(sWorkingDir));
+#ifdef DEFAULT_FILE_ENCODING
+		wchar_t sWorkingDir16[512 + 1] = { 0 };
+		memset(sWorkingDir16, 0, sizeof(sWorkingDir16));
+		::GetCurrentDirectoryW(MAX_PATH, sWorkingDir16);
+		auto _sWorkingDir = StringHelper::WideCharToMultiByte(sWorkingDir16, DEFAULT_FILE_ENCODING);
+		strcpy(sWorkingDir, _sWorkingDir);
+#else
 		::GetCurrentDirectory(MAX_PATH, sWorkingDir);
+#endif
 		m_sInitialWorkingDir = sWorkingDir;
 #ifdef PARAENGINE_MOBILE
 		CGlobals::GetFileManager()->AddDiskSearchPath(sWorkingDir);

--- a/Client/trunk/ParaEngineClient/ParaEngineClientConfig.win32.h
+++ b/Client/trunk/ParaEngineClient/ParaEngineClientConfig.win32.h
@@ -79,3 +79,4 @@ smaller than this value(measured in pixels), then shadows will NOT be casted for
 /** default encoding for char * in GUI system.  UTF8 is a good choice, although ansi code page is also fine. */
 //#define DEFAULT_GUI_ENCODING		CP_ACP
 #define DEFAULT_GUI_ENCODING		CP_UTF8
+#define DEFAULT_FILE_ENCODING		CP_UTF8

--- a/Client/trunk/ParaEngineClient/ParaScriptBindings/ParaScriptingGlobal.cpp
+++ b/Client/trunk/ParaEngineClient/ParaScriptBindings/ParaScriptingGlobal.cpp
@@ -1976,6 +1976,15 @@ bool ParaScripting::ParaGlobal::OpenFileDialog(const object& inout)
 	}
 	char buf[MAX_LINE + 1] = { 0 };
 	int nCount = GetCurrentDirectory(MAX_LINE, buf);
+#ifdef DEFAULT_FILE_ENCODING
+	wchar_t sWorkingDir16[MAX_LINE + 1] = { 0 };
+	memset(sWorkingDir16, 0, sizeof(sWorkingDir16));
+	::GetCurrentDirectoryW(MAX_PATH, sWorkingDir16);
+	auto _sWorkingDir = StringHelper::WideCharToMultiByte(sWorkingDir16, DEFAULT_FILE_ENCODING);
+	strcpy(buf, _sWorkingDir);
+#else
+	::GetCurrentDirectory(MAX_PATH, sWorkingDir);
+#endif
 
 	// switch to windowed mode to display the win32 common dialog.
 	bool bOldWindowed = CParaEngineApp::GetInstance()->IsWindowedMode();  // Preserve original windowed flag
@@ -1992,8 +2001,15 @@ bool ParaScripting::ParaGlobal::OpenFileDialog(const object& inout)
 	}
 
 	// reset directory. 
-	if (nCount > 0)
+	if (nCount > 0) {
+#ifdef DEFAULT_FILE_ENCODING
+		LPCWSTR buf16 = StringHelper::MultiByteToWideChar(buf, DEFAULT_FILE_ENCODING);
+		SetCurrentDirectoryW(buf16);
+#else
 		SetCurrentDirectory(buf);
+#endif
+	}
+		
 
 	inout["result"] = bResult;
 	if (bResult)

--- a/Client/trunk/ParaEngineClient/ParaScriptBindings/ParaScriptingIO.cpp
+++ b/Client/trunk/ParaEngineClient/ParaScriptBindings/ParaScriptingIO.cpp
@@ -872,7 +872,7 @@ namespace ParaScripting
 			}
 			
 
-			string sSrcPath = dest;
+			string sSrcPath = src;
 			//TODO: search if the directory is outside the application directory. If so, we should now allow user to delete file there.
 			if (!CParaFile::IsWritablePath(sSrcPath))
 			{

--- a/Client/trunk/ParaEngineClient/util/CommonFileDialog.cpp
+++ b/Client/trunk/ParaEngineClient/util/CommonFileDialog.cpp
@@ -9,6 +9,7 @@
 #include <shlobj.h>
 
 #include "CommonFileDialog.h"
+#include "StringHelper.h"
 
 using namespace ParaEngine;
 
@@ -31,8 +32,17 @@ INT CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg,
 	case BFFM_INITIALIZED:
 		if (pData) 
 			strcpy(szDir, (TCHAR *)pData);
-		else 
-			GetCurrentDirectory(sizeof(szDir) / sizeof(TCHAR), szDir);
+		else {
+#ifdef DEFAULT_FILE_ENCODING
+			wchar_t sWorkingDir16[MAX_PATH] = { 0 };
+			memset(sWorkingDir16, 0, sizeof(sWorkingDir16));
+			::GetCurrentDirectoryW(MAX_PATH, sWorkingDir16);
+			auto _sWorkingDir = StringHelper::WideCharToMultiByte(sWorkingDir16, DEFAULT_FILE_ENCODING);
+			strcpy(szDir, _sWorkingDir);
+#else
+			::GetCurrentDirectory(sizeof(szDir) / sizeof(TCHAR), szDir);
+#endif
+		}
 
 		//selects the specified folder 
 		//in the Browse For Folder dialog box

--- a/Client/trunk/ParaEngineClient/util/StringHelper.h
+++ b/Client/trunk/ParaEngineClient/util/StringHelper.h
@@ -249,6 +249,9 @@ namespace ParaEngine
 			public:
 				_CodePageName()
 				{
+#ifdef DEFAULT_GUI_ENCODING
+					name = "utf-8";
+#else
 #ifdef WIN32
 					auto cp = GetACP();
 					char tmp[30];
@@ -258,6 +261,7 @@ namespace ParaEngine
 					name += tmp;
 #else
 					name = "utf-8";
+#endif
 #endif
 				}
 


### PR DESCRIPTION
解决方案是：加上DEFAULT_FILE_ENCODING宏，windows文件相关，使用utf8编码，全部转成 wchar_t*