### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/Client/trunk/externals/bullet3/btgui/lua-5.2.3/src/lparser.c
+++ b/Client/trunk/externals/bullet3/btgui/lua-5.2.3/src/lparser.c
@@ -301,6 +301,7 @@ static void singlevar (LexState *ls, expdesc *var) {
     expdesc key;
     singlevaraux(fs, ls->envn, var, 1);  /* get environment variable */
     lua_assert(var->k == VLOCAL || var->k == VUPVAL);
+    luaK_exp2anyregup(fs, var);  /* but could be a constant */
     codestring(ls, &key, varname);  /* key is variable name */
     luaK_indexed(fs, var, &key);  /* env[varname] */
   }


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in Client/trunk/externals/bullet3/btgui/lua-5.2.3/src/lparser.c which was cloned from lua/lua but did not receive the security patch applied in lua/lua. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2022-28805.

### Proposed Fix
Apply the same patch as the one in lua/lua to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2022-28805
https://github.com/lua/lua/commit/1f3c6f4534c6411313361697d98d1145a1f030fa