### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/Server/trunk/curl-7.47.1/src/tool_writeout.c
+++ b/Server/trunk/curl-7.47.1/src/tool_writeout.c
@@ -107,7 +107,7 @@ void ourWriteOut(CURL *curl, struct OutStruct *outs, const char *writeinfo)
   double doubleinfo;
 
   while(ptr && *ptr) {
-    if('%' == *ptr) {
+    if('%' == *ptr && ptr[1]) {
       if('%' == ptr[1]) {
         /* an escaped %-letter */
         fputc('%', stream);


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in Server/trunk/curl-7.47.1/src/tool_writeout.c which was cloned from curl/curl but did not receive the security patch applied in curl/curl. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2017-7407.

### Proposed Fix
Apply the same patch as the one in curl/curl to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2017-7407
https://github.com/curl/curl/commit/1890d59905414ab84a35892b2e45833654aa5c13