### PR TITLE
refactor(webview): use CMAKE_MSVC_RUNTIME_LIBRARY for static MSVC run…

### DIFF
--- a/Client/trunk/externals/webview/CMakeLists.txt
+++ b/Client/trunk/externals/webview/CMakeLists.txt
@@ -8,15 +8,9 @@ project(webview)
 set(BoostRoot_DIR "$ENV{BOOST_ROOT}")
 
 IF(MSVC)
-	# statically link MSVC to reduce dependancies
-	foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
-	 	if(${flag_var} MATCHES "/MD")
-			string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-	 	endif(${flag_var} MATCHES "/MD")
-	 	if(${flag_var} MATCHES "/MDd")
-	 		string(REGEX REPLACE "/MDd" "/MTd" ${flag_var} "${${flag_var}}")
-		endif(${flag_var} MATCHES "/MDd")
-	endforeach(flag_var)
+	# Statically link MSVC runtime for all configurations.
+	# Debug: /MTd (MultiThreadedDebug), Release: /MT (MultiThreaded)
+	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 	# enable multiprocessor build option /MP, this will greatly increase compile speed
 	SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MP")
@@ -75,15 +69,9 @@ set(LibName "ParaWebView")
 set(CMAKE_DEBUG_POSTFIX "_d")
 
 IF(MSVC)
-	# statically link MSVC to reduce dependancies
-	foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
-	 	if(${flag_var} MATCHES "/MD")
-			string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-	 	endif(${flag_var} MATCHES "/MD")
-	 	if(${flag_var} MATCHES "/MDd")
-	 		string(REGEX REPLACE "/MDd" "/MTd" ${flag_var} "${${flag_var}}")
-		endif(${flag_var} MATCHES "/MDd")
-	endforeach(flag_var)
+	# Statically link MSVC runtime for all configurations.
+	# Debug: /MTd (MultiThreadedDebug), Release: /MT (MultiThreaded)
+	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 	# enable multiprocessor build option /MP, this will greatly increase compile speed
 	SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MP")


### PR DESCRIPTION
…time linking

Replace legacy foreach/REGEX REPLACE /MD->/MT pattern with modern CMake CMAKE_MSVC_RUNTIME_LIBRARY property for both webview and ParaWebView targets.