### PR TITLE
fix(cp_old): backport input buffer overflow and texture sequence UAF fixes

### DIFF
--- a/NPLRuntime/ParaEngine/2dengine/GUIKeyboardVirtual.cpp
+++ b/NPLRuntime/ParaEngine/2dengine/GUIKeyboardVirtual.cpp
@@ -58,10 +58,12 @@ CGUIBase* ParaEngine::CGUIKeyboardVirtual::GetCapture()
 
 void ParaEngine::CGUIKeyboardVirtual::PushKeyEvent(const DeviceKeyEvent& e)
 {
+	// when the buffer is full, drop the event; the count must never exceed the array size,
+	// otherwise ReadBufferedData will read/write out of bounds.
 	if (m_buffered_key_msgs_count < SAMPLE_BUFFER_SIZE / 2) {
 		m_buffered_key_msgs[m_buffered_key_msgs_count] = e;
+		++m_buffered_key_msgs_count;
 	}
-	++m_buffered_key_msgs_count;
 }
 
 void ParaEngine::CGUIKeyboardVirtual::Update()
@@ -82,7 +84,11 @@ HRESULT ParaEngine::CGUIKeyboardVirtual::ReadBufferedData()
 	Only immediate button data are read from direct input. */
 	m_dwElements = 0;
 	//translating windows message into DirextMouse-like events, in order to maintain consistency of the interface
-	for (int a = 0; a<m_buffered_key_msgs_count; a++) {
+	// defensive clamp: never trust the count beyond the actual buffer capacity.
+	int nMsgCount = m_buffered_key_msgs_count;
+	if (nMsgCount > SAMPLE_BUFFER_SIZE / 2)
+		nMsgCount = SAMPLE_BUFFER_SIZE / 2;
+	for (int a = 0; a<nMsgCount && m_dwElements < SAMPLE_BUFFER_SIZE; a++) {
 		m_didod[m_dwElements].dwOfs = 0;
 		switch (m_buffered_key_msgs[a].m_state) {
 		case EKeyState::PRESS:

--- a/NPLRuntime/ParaEngine/Core/TextureEntityDirectX.cpp
+++ b/NPLRuntime/ParaEngine/Core/TextureEntityDirectX.cpp
@@ -65,6 +65,10 @@ TextureEntityDirectX::~TextureEntityDirectX()
 	{
 		UnloadAsset();
 	}
+	// Free the texture-sequence array only here (at entity destruction). Any pending
+	// async load holds an asset_ptr to this entity, so reaching the destructor
+	// guarantees no loader still references &m_pTextureSequence[i]. See DeleteDeviceObjects().
+	SAFE_DELETE_ARRAY(m_pTextureSequence);
 }
 
 
@@ -827,9 +831,19 @@ HRESULT TextureEntityDirectX::DeleteDeviceObjects()
 			{
 				for (int i=1;i<=nTotalTextureSequence;++i)
 				{
-					SAFE_RELEASE(m_pTextureSequence[i-1]);
+					SAFE_RELEASE(m_pTextureSequence[i-1]);   // release and null each frame slot
 				}
-				SAFE_DELETE_ARRAY(m_pTextureSequence);
+				// Do NOT SAFE_DELETE_ARRAY(m_pTextureSequence) here.
+				// This function is also called on device reset / manual unload while the
+				// entity is still alive, and pending async loads (CTextureLoader/
+				// CTextureProcessor) may still be queued in CAsyncLoader holding
+				// &m_pTextureSequence[i] as their write-back target. Freeing the array
+				// here would leave them with a dangling pointer -> use-after-free crash
+				// when they later run SAFE_RELEASE(*ppTexture). The array lives for the
+				// entity's whole lifetime and is freed in the destructor instead (by then
+				// the asset_ptr held by any loader guarantees no async work remains).
+				// Slots are nulled above, so a late completion just Release(NULL)s and
+				// stores the new texture. See ~TextureEntityDirectX().
 			}
 			break;
 		}


### PR DESCRIPTION
﻿## Summary

Backport of the two crash fixes merged to `dev` in #835 (commits 7487084e and 5f82fe96) to the `cp_old` branch, which shares the same vulnerable code in its `NPLRuntime/ParaEngine/` source tree.

### fix(gui): out-of-bounds access in virtual keyboard event buffer

`CGUIKeyboardVirtual::PushKeyEvent` incremented `m_buffered_key_msgs_count` even when the buffer was already full, so under heavy input the count could grow past `SAMPLE_BUFFER_SIZE/2`. `ReadBufferedData` then iterated with that count, reading past `m_buffered_key_msgs` and writing past `m_didod`, corrupting the heap.

- Only increment the count when the event is actually stored.
- Defensively clamp the count in `ReadBufferedData` and bound `m_dwElements` to the `m_didod` capacity.

Note: unlike `dev`, cp_old's `CGUIMouseVirtual` was already rewritten with the increment inside the bounds check, so only the keyboard path needs the fix on this branch.

### fix(texture): use-after-free on texture sequence array during async load

`TextureEntityDirectX::DeleteDeviceObjects()` freed `m_pTextureSequence` while pending async loaders (`CTextureLoader`/`CTextureProcessor` queued in `CAsyncLoader`) could still hold `&m_pTextureSequence[i]` as their write-back target. When such a loader later completed it dereferenced the freed array (`SAFE_RELEASE(*ppTexture)`), crashing with a use-after-free.

The fix keeps the array alive for the whole entity lifetime: `DeleteDeviceObjects` only releases and nulls each frame slot, and the array itself is freed in the destructor. By then any pending loader has released its `asset_ptr` to the entity, so no async work can still reference the array.
